### PR TITLE
Protect volume deletion

### DIFF
--- a/purestorage/general_test.go
+++ b/purestorage/general_test.go
@@ -38,7 +38,7 @@ func TestAccResourcePureLargeTest(t *testing.T) {
 func testAccCheckPureHostConfigFullSetup(numberOfHosts int, numberOfVolumes int, testID string) string {
 	output := ""
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfhosttest-volumegroup" {
+		resource "purefa_volumegroup" "tfhosttest-volumegroup" {
 			name = "tfhosttest-volumegroup-%s"
 		}
 		`, testID)
@@ -46,7 +46,7 @@ func testAccCheckPureHostConfigFullSetup(numberOfHosts int, numberOfVolumes int,
 		resource "purefa_volume" "tfhosttest-volumes" {
 			name = "tfhosttest-volume-%s-${count.index}"
 			size = 1024000000
-			volume_group = purefa_vgroup.tfhosttest-volumegroup.name
+			volume_group = purefa_volumegroup.tfhosttest-volumegroup.name
 			count = %d
 		}
 		`, testID, numberOfVolumes)

--- a/purestorage/provider.go
+++ b/purestorage/provider.go
@@ -92,7 +92,7 @@ func Provider() *schema.Provider {
 			"purefa_host":            resourcePureHost(),
 			"purefa_hostgroup":       resourcePureHostgroup(),
 			"purefa_protectiongroup": resourcePureProtectiongroup(),
-			"purefa_vgroup":          resourcePureVolumegroup(),
+			"purefa_volumegroup":     resourcePureVolumegroup(),
 			// "purefa_network_interface": resourcePureNetworkInterface(),
 			"purefa_dns_settings":    resourcePureDnsSettings(),
 			"purefa_alert_recipient": resourcePureAlertRecipient(),

--- a/purestorage/resource_host_test.go
+++ b/purestorage/resource_host_test.go
@@ -222,7 +222,7 @@ func TestAccResourcePureHost_volumeWithVolumegroup(t *testing.T) {
 	testID := strconv.Itoa(acctest.RandInt())
 
 	resource_name_volume := "purefa_volume.tfhosttest-volume"
-	resource_name_vgroup := "purefa_vgroup.tfhosttest-volumegroup"
+	resource_name_vgroup := "purefa_volumegroup.tfhosttest-volumegroup"
 	resource_name_host := "purefa_host.tfhosttest"
 
 	resource.Test(t, resource.TestCase{
@@ -557,7 +557,7 @@ resource "purefa_host" "tfhosttest" {
 func testAccCheckPureHostConfigWithVolumeAndVolumegroup(testID string) string {
 	output := ""
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfhosttest-volumegroup" {
+		resource "purefa_volumegroup" "tfhosttest-volumegroup" {
 			name = "tfhosttest-volumegroup-%s"
 		}
 		`, testID)
@@ -565,7 +565,7 @@ func testAccCheckPureHostConfigWithVolumeAndVolumegroup(testID string) string {
 		resource "purefa_volume" "tfhosttest-volume" {
 			name = "tfhosttest-volume-%s"
 			size = 1024000000
-			volume_group = purefa_vgroup.tfhosttest-volumegroup.name
+			volume_group = purefa_volumegroup.tfhosttest-volumegroup.name
 		}
 		`, testID)
 

--- a/purestorage/resource_vgroup_test.go
+++ b/purestorage/resource_vgroup_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-const testAccCheckPureVolumeGroupResourceName = "purefa_vgroup.tfvolumegrouptest"
+const testAccCheckPureVolumeGroupResourceName = "purefa_volumegroup.tfvolumegrouptest"
 
 // The volumes created in theses tests will not be eradicated.
 //
@@ -115,7 +115,7 @@ func testAccCheckPureVolumeGroupDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*flasharray.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "purefa_vgroup" {
+		if rs.Type != "purefa_volumegroup" {
 			continue
 		}
 
@@ -144,7 +144,7 @@ func testAccCheckPureVolumeGroupEradicate(s *terraform.State) error {
 	client := testAccProvider.Meta().(*flasharray.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "purefa_vgroup" {
+		if rs.Type != "purefa_volumegroup" {
 			continue
 		}
 
@@ -193,7 +193,7 @@ func testAccCheckPureVolumeGroupCount(testID string, count int) resource.TestChe
 		rsCount := 0
 		vgCount := 0
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "purefa_vgroup" {
+			if rs.Type != "purefa_volumegroup" {
 				continue
 			}
 
@@ -228,7 +228,7 @@ func testAccCheckPureVolumeGroupCount(testID string, count int) resource.TestChe
 
 func testAccCheckPureVolumeGroupConfig(vgroupName string, testID int) string {
 	return fmt.Sprintf(`
-resource "purefa_vgroup" "tfvolumegrouptest" {
+resource "purefa_volumegroup" "tfvolumegrouptest" {
         name = "%s-%d"
 }`, vgroupName, testID)
 }
@@ -236,14 +236,14 @@ resource "purefa_vgroup" "tfvolumegrouptest" {
 func testAccCheckPureVolumeGroupConfigWithVolumes(vgroupName string, volumeName string, numerOfVolumes int, testID int) string {
 	output := ""
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfvolumegrouptest" {
+		resource "purefa_volumegroup" "tfvolumegrouptest" {
 				name = "%s-%d"
 		}`, vgroupName, testID)
 	output += fmt.Sprintf(`
 		resource "purefa_volume" "tfvolumetest" {
 			name = "%s-%d-${count.index}"
 			size = 1024000000
-			volume_group = purefa_vgroup.tfvolumegrouptest.name
+			volume_group = purefa_volumegroup.tfvolumegrouptest.name
 			count = %d
 		}`, volumeName, testID, numerOfVolumes)
 	return output
@@ -252,7 +252,7 @@ func testAccCheckPureVolumeGroupConfigWithVolumes(vgroupName string, volumeName 
 func testAccCheckPureVolumeGroupConfigWithoutVolumes(vgroupName string, volumeName string, numerOfVolumes int, testID int) string {
 	output := ""
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfvolumegrouptest" {
+		resource "purefa_volumegroup" "tfvolumegrouptest" {
 				name = "%s-%d"
 		}`, vgroupName, testID)
 	output += fmt.Sprintf(`
@@ -267,18 +267,18 @@ func testAccCheckPureVolumeGroupConfigWithoutVolumes(vgroupName string, volumeNa
 func testAccCheckPureVolumeGroupConfigMoveVolumes(vgroupName string, volumeName string, numerOfVolumes int, testID int) string {
 	output := ""
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfvolumegrouptest" {
+		resource "purefa_volumegroup" "tfvolumegrouptest" {
 				name = "%s-%d"
 		}`, vgroupName, testID)
 	output += fmt.Sprintf(`
-		resource "purefa_vgroup" "tfvolumegrouptest2" {
+		resource "purefa_volumegroup" "tfvolumegrouptest2" {
 				name = "%s-%d-2"
 		}`, vgroupName, testID)
 	output += fmt.Sprintf(`
 		resource "purefa_volume" "tfvolumetest" {
 			name = "%s-%d-${count.index}"
 			size = 1024000000
-			volume_group = purefa_vgroup.tfvolumegrouptest2.name
+			volume_group = purefa_volumegroup.tfvolumegrouptest2.name
 			count = %d
 		}`, volumeName, testID, numerOfVolumes)
 	return output

--- a/purestorage/resource_volume_test.go
+++ b/purestorage/resource_volume_test.go
@@ -245,6 +245,7 @@ func testAccCheckPureVolumeConfig(rInt int) string {
 resource "purefa_volume" "tfvolumetest" {
         name = "tfvolumetest-%d"
         size = 1024000000
+		allow_destroy = true
 }`, rInt)
 }
 
@@ -253,11 +254,13 @@ func testAccCheckPureVolumeConfigClone(rInt int) string {
 resource "purefa_volume" "tfvolumetest" {
         name = "tfvolumetest-%d"
         size = 1024000000
+		allow_destroy = true
 }
 
 resource "purefa_volume" "tfclonevolumetest" {
         name = "tfclonevolumetest-%d"
         source = "${purefa_volume.tfvolumetest.name}"
+		allow_destroy = true
 }`, rInt, rInt)
 }
 
@@ -266,6 +269,7 @@ func testAccCheckPureVolumeConfigResize(rInt int) string {
 resource "purefa_volume" "tfvolumetest" {
 	name = "tfvolumetest-%d"
 	size = 2048000000
+	allow_destroy = true
 }`, rInt)
 }
 
@@ -274,5 +278,6 @@ func testAccCheckPureVolumeConfigRename(rInt int) string {
 resource "purefa_volume" "tfvolumetest" {
         name = "tfvolumetest-rename-%d"
         size = 2048000000
+		allow_destroy = true
 }`, rInt)
 }


### PR DESCRIPTION
Prevent accidental removal of volumes by adding an `allow_destroy` parameter. 

```
resource "purefa_volume" "can_not_remove" {
        name = "tfvolumetest"
        size = 2048000000
	allow_destroy = false
}

resource "purefa_volume" "can_remove" {
        name = "tfvolumetest"
        size = 2048000000
	allow_destroy = true
}
```